### PR TITLE
Add animator-driven pose grid auto generation

### DIFF
--- a/aiCam/Assets/Editor/PoseGridLayoutEditor.cs
+++ b/aiCam/Assets/Editor/PoseGridLayoutEditor.cs
@@ -1,9 +1,13 @@
 using UnityEditor;
 using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.Animations;
 
 [CustomEditor(typeof(PoseGridLayout))]
 public class PoseGridLayoutEditor : Editor
 {
+    SerializedProperty editorTargetAnimator;
     SerializedProperty contentRect;
     SerializedProperty slotPrefab;
     SerializedProperty items;
@@ -14,9 +18,12 @@ public class PoseGridLayoutEditor : Editor
     SerializedProperty minCellWidth;
     SerializedProperty autoScrollToTop;
     SerializedProperty fullRebuildOnUpdate;
+    SerializedProperty targetLayerIndex;
+    SerializedProperty crossFadeTime;
 
     void OnEnable()
     {
+        editorTargetAnimator = serializedObject.FindProperty("editorTargetAnimator");
         contentRect         = serializedObject.FindProperty("contentRect");
         slotPrefab          = serializedObject.FindProperty("slotPrefab");
         items               = serializedObject.FindProperty("items");
@@ -27,12 +34,15 @@ public class PoseGridLayoutEditor : Editor
         minCellWidth        = serializedObject.FindProperty("minCellWidth");
         autoScrollToTop     = serializedObject.FindProperty("autoScrollToTop");
         fullRebuildOnUpdate = serializedObject.FindProperty("fullRebuildOnUpdate");
+        targetLayerIndex    = serializedObject.FindProperty("targetLayerIndex");
+        crossFadeTime       = serializedObject.FindProperty("crossFadeTime");
     }
 
     public override void OnInspectorGUI()
     {
         serializedObject.Update();
 
+        EditorGUILayout.PropertyField(editorTargetAnimator, new GUIContent("Editor Target Animator"));
         EditorGUILayout.PropertyField(contentRect);
         EditorGUILayout.PropertyField(slotPrefab);
 
@@ -56,12 +66,81 @@ public class PoseGridLayoutEditor : Editor
         EditorGUILayout.PropertyField(autoScrollToTop, new GUIContent("Auto Scroll To Top"));
 
         EditorGUILayout.Space(6);
+        EditorGUILayout.LabelField("Animator Settings", EditorStyles.boldLabel);
+        EditorGUILayout.PropertyField(targetLayerIndex, new GUIContent("Target Layer Index"));
+        EditorGUILayout.PropertyField(crossFadeTime, new GUIContent("Cross Fade Time"));
+
+        EditorGUILayout.Space(6);
         EditorGUILayout.LabelField("Rebuild Policy", EditorStyles.boldLabel);
         EditorGUILayout.PropertyField(fullRebuildOnUpdate, new GUIContent("Full Rebuild on Update"));
 
         EditorGUILayout.Space(10);
         using (new EditorGUILayout.HorizontalScope())
         {
+            if (GUILayout.Button("AnimatorからItemsを自動生成", GUILayout.Height(28)))
+            {
+                serializedObject.ApplyModifiedProperties();
+                GUI.FocusControl(null);
+
+                var grid = (PoseGridLayout)target;
+                var animator = grid.editorTargetAnimator;
+                if (!animator)
+                {
+                    animator = grid.GetComponentInParent<Animator>();
+                    if (!animator)
+                        animator = Object.FindFirstObjectByType<Animator>(FindObjectsInactive.Include);
+                }
+
+                if (!animator || animator.runtimeAnimatorController == null)
+                {
+                    EditorUtility.DisplayDialog("Animator が見つかりません",
+                        "PoseGridLayout.editorTargetAnimator に RuntimeAnimatorController が設定された Animator を割り当ててください。",
+                        "OK");
+                    return;
+                }
+
+                var rac = animator.runtimeAnimatorController;
+                var entries = new List<(AnimationClip clip, string statePath)>();
+                if (!TryCollectLayerClips(rac, grid.TargetLayerIndex, entries))
+                {
+                    EditorUtility.DisplayDialog("Animator レイヤーが見つかりません",
+                        $"Animator Controller にレイヤー {grid.TargetLayerIndex} が存在しません。Animator を確認してください。",
+                        "OK");
+                    return;
+                }
+
+                var unique = entries
+                    .Where(e => e.clip != null)
+                    .GroupBy(e => e.clip.GetInstanceID())
+                    .Select(g => g.First())
+                    .OrderBy(e => e.clip.name, System.StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                var newItems = new List<PoseItem>(unique.Count);
+                foreach (var entry in unique)
+                {
+                    var item = new PoseItem
+                    {
+                        clip = entry.clip,
+                        thumbnail = null,
+                        displayNameOverride = string.Empty,
+                        statePath = entry.statePath
+                    };
+                    newItems.Add(item);
+                }
+
+                Undo.RecordObject(grid, "Generate Pose Items from Animator");
+                grid.editorTargetAnimator = animator;
+                grid.SetItems(newItems, andRebuild: true);
+                EditorUtility.SetDirty(grid);
+
+                EditorUtility.DisplayDialog("完了",
+                    $"Animator から {unique.Count} 個の AnimationClip を items に設定しました。",
+                    "OK");
+
+                serializedObject.Update();
+            }
+
             if (GUILayout.Button("Update", GUILayout.Height(28)))
             {
                 // これを最初に！ ここまでの Inspector 入力を実体へ反映
@@ -86,5 +165,85 @@ public class PoseGridLayoutEditor : Editor
         }
 
         serializedObject.ApplyModifiedProperties();
+    }
+
+    private bool TryCollectLayerClips(RuntimeAnimatorController ctrl, int layerIndex, List<(AnimationClip clip, string statePath)> destination)
+    {
+        if (ctrl == null) return false;
+
+        var overrideMap = new Dictionary<AnimationClip, AnimationClip>();
+        AnimatorController baseController = null;
+
+        void Traverse(RuntimeAnimatorController current)
+        {
+            switch (current)
+            {
+                case AnimatorOverrideController aoc:
+                    Traverse(aoc.runtimeAnimatorController);
+                    var overrides = new List<KeyValuePair<AnimationClip, AnimationClip>>();
+                    aoc.GetOverrides(overrides);
+                    foreach (var pair in overrides)
+                    {
+                        if (pair.Value != null)
+                            overrideMap[pair.Key] = pair.Value;
+                        else
+                            overrideMap.Remove(pair.Key);
+                    }
+                    break;
+                case AnimatorController ac:
+                    baseController = ac;
+                    break;
+            }
+        }
+
+        Traverse(ctrl);
+
+        if (baseController == null) return false;
+        if (layerIndex < 0 || layerIndex >= baseController.layers.Length) return false;
+
+        AnimationClip ResolveClip(AnimationClip original)
+        {
+            if (original == null) return null;
+            if (overrideMap.TryGetValue(original, out var overridden) && overridden != null)
+                return overridden;
+            return original;
+        }
+
+        void CollectFromMotion(Motion motion, string statePath)
+        {
+            if (motion == null) return;
+            switch (motion)
+            {
+                case AnimationClip clip:
+                    destination.Add((ResolveClip(clip), statePath));
+                    break;
+                case BlendTree blendTree:
+                    foreach (var child in blendTree.children)
+                        CollectFromMotion(child.motion, statePath);
+                    break;
+            }
+        }
+
+        void CollectFromStateMachine(AnimatorStateMachine stateMachine, string pathPrefix)
+        {
+            foreach (var childState in stateMachine.states)
+            {
+                string statePath = string.IsNullOrEmpty(pathPrefix)
+                    ? childState.state.name
+                    : $"{pathPrefix}.{childState.state.name}";
+                CollectFromMotion(childState.state.motion, statePath);
+            }
+
+            foreach (var childMachine in stateMachine.stateMachines)
+            {
+                string childPath = string.IsNullOrEmpty(pathPrefix)
+                    ? childMachine.stateMachine.name
+                    : $"{pathPrefix}.{childMachine.stateMachine.name}";
+                CollectFromStateMachine(childMachine.stateMachine, childPath);
+            }
+        }
+
+        CollectFromStateMachine(baseController.layers[layerIndex].stateMachine, string.Empty);
+        return true;
     }
 }

--- a/aiCam/Assets/Prefabs/PoseSlot.prefab
+++ b/aiCam/Assets/Prefabs/PoseSlot.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 2974863074263378924}
   - component: {fileID: 9092875010207951701}
   - component: {fileID: 2697143086322141266}
+  - component: {fileID: -4032288765432198765}
   m_Layer: 5
   m_Name: PoseSlot
   m_TagString: Untagged
@@ -132,9 +133,26 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86067133153394a73a70d958e38b9da8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   tmpText: {fileID: 6573363265125866751}
+--- !u!114 &-4032288765432198765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 126201095108214450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 174e3f16018e4fd3977ed12ae8c1f533, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  animator: {fileID: 0}
+  layerIndex: 2
+  crossFadeTime: 0.1
+  statePath:
+  clip: {fileID: 0}
 --- !u!1 &3306106851116749376
 GameObject:
   m_ObjectHideFlags: 0

--- a/aiCam/Assets/Scripts/ButtonPoseAction.cs
+++ b/aiCam/Assets/Scripts/ButtonPoseAction.cs
@@ -1,0 +1,139 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+[RequireComponent(typeof(Button))]
+public class ButtonPoseAction : MonoBehaviour
+{
+    [Header("Animator")] public Animator animator;
+    [Min(0)] public int layerIndex = 2;
+    [Min(0f)] public float crossFadeTime = 0.1f;
+
+    [Header("State")]
+    public string statePath;
+    public AnimationClip clip;
+
+    private Button cachedButton;
+
+    private void Awake()
+    {
+        cachedButton = GetComponent<Button>();
+        if (cachedButton != null)
+        {
+            cachedButton.onClick.RemoveListener(Apply);
+            cachedButton.onClick.AddListener(Apply);
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (cachedButton == null)
+        {
+            cachedButton = GetComponent<Button>();
+            if (cachedButton != null)
+            {
+                cachedButton.onClick.RemoveListener(Apply);
+                cachedButton.onClick.AddListener(Apply);
+            }
+        }
+    }
+
+    public void Configure(Animator animator, string statePath, AnimationClip clip, float crossFadeTime, int layerIndex)
+    {
+        this.animator = animator;
+        this.statePath = statePath;
+        this.clip = clip;
+        if (crossFadeTime >= 0f) this.crossFadeTime = crossFadeTime;
+        this.layerIndex = Mathf.Max(0, layerIndex);
+    }
+
+    public void Apply()
+    {
+        var targetAnimator = animator;
+        if (!targetAnimator)
+        {
+            Debug.LogWarning($"[{nameof(ButtonPoseAction)}] Animator is null on {name}.");
+            return;
+        }
+
+        if (targetAnimator.layerCount == 0)
+        {
+            Debug.LogWarning($"[{nameof(ButtonPoseAction)}] Animator {targetAnimator} has no layers.", targetAnimator);
+            return;
+        }
+
+        int layer = Mathf.Clamp(layerIndex, 0, targetAnimator.layerCount - 1);
+
+        string resolvedPath = ResolveStatePath(targetAnimator, layer);
+        if (string.IsNullOrEmpty(resolvedPath))
+        {
+            Debug.LogWarning($"[{nameof(ButtonPoseAction)}] State path is empty on {name}.");
+            return;
+        }
+
+        int stateHash = Animator.StringToHash(resolvedPath);
+        if (!targetAnimator.HasState(layer, stateHash))
+        {
+            string fallback = BuildFallbackStatePath(targetAnimator, layer, resolvedPath);
+            if (!string.IsNullOrEmpty(fallback))
+            {
+                stateHash = Animator.StringToHash(fallback);
+            }
+
+            if (!targetAnimator.HasState(layer, stateHash))
+            {
+                Debug.LogWarning($"[{nameof(ButtonPoseAction)}] State '{resolvedPath}' not found on layer {layer} of {targetAnimator}.", targetAnimator);
+                return;
+            }
+        }
+
+        targetAnimator.CrossFade(stateHash, crossFadeTime, layer);
+    }
+
+    private string ResolveStatePath(Animator animator, int layer)
+    {
+        string path = statePath;
+        if (string.IsNullOrEmpty(path))
+        {
+            path = clip ? clip.name : string.Empty;
+        }
+        if (string.IsNullOrEmpty(path))
+        {
+            return string.Empty;
+        }
+
+        path = path.Replace('/', '.');
+
+        if (!path.Contains("."))
+        {
+            string layerName = SafeGetLayerName(animator, layer);
+            if (!string.IsNullOrEmpty(layerName))
+            {
+                path = $"{layerName}.{path}";
+            }
+        }
+
+        return path;
+    }
+
+    private string BuildFallbackStatePath(Animator animator, int layer, string original)
+    {
+        string layerName = SafeGetLayerName(animator, layer);
+        if (!string.IsNullOrEmpty(layerName) && original.StartsWith(layerName + "."))
+        {
+            string withoutLayer = original.Substring(layerName.Length + 1);
+            if (!string.IsNullOrEmpty(withoutLayer))
+            {
+                return $"{layerName}.{withoutLayer.Replace('/', '.')}";
+            }
+        }
+
+        return original.Replace('/', '.');
+    }
+
+    private static string SafeGetLayerName(Animator animator, int layer)
+    {
+        if (!animator) return string.Empty;
+        if (layer < 0 || layer >= animator.layerCount) return string.Empty;
+        return animator.GetLayerName(layer);
+    }
+}

--- a/aiCam/Assets/Scripts/ButtonPoseAction.cs.meta
+++ b/aiCam/Assets/Scripts/ButtonPoseAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 174e3f16018e4fd3977ed12ae8c1f533

--- a/aiCam/Assets/Scripts/UI/Pose/PoseGridLayout.cs
+++ b/aiCam/Assets/Scripts/UI/Pose/PoseGridLayout.cs
@@ -11,6 +11,13 @@ using UnityEditor.Experimental.SceneManagement;
 [ExecuteAlways]
 public class PoseGridLayout : MonoBehaviour
 {
+    [Header("Editor 用ターゲット（固定生成に使用）")]
+    public Animator editorTargetAnimator;
+
+    [Header("Runtime Target")]
+    [SerializeField, ReadOnly]
+    private Animator runtimeTargetAnimator;
+
     [Header("Target Area (ScrollRect Content 推奨)")]
     [SerializeField] private RectTransform contentRect;
 
@@ -28,6 +35,10 @@ public class PoseGridLayout : MonoBehaviour
     [SerializeField] private bool squareCell = true;
     [Min(0)] [SerializeField] private float minCellWidth = 0f;
     [SerializeField] private bool autoScrollToTop = true;
+
+    [Header("Animator Settings")]
+    [SerializeField, Min(0)] private int targetLayerIndex = 2;
+    [SerializeField, Min(0f)] private float crossFadeTime = 0.1f;
 
     [Header("Rebuild Policy")]
     [Tooltip("Update 押下時に一度すべての子を削除し、必要数だけ新規生成します。")]
@@ -132,8 +143,10 @@ public class PoseGridLayout : MonoBehaviour
                 string label = !string.IsNullOrEmpty(it.displayNameOverride)
                              ? it.displayNameOverride
                              : (it.clip ? it.clip.name : "(None)");
-                slot.Bind(it.clip, i, it.thumbnail, label);
+                slot.Bind(it.clip, i, it.thumbnail, label, it.statePath);
             }
+
+            ConfigureButtonForIndex(child.GetComponent<ButtonPoseAction>(), i);
         }
 
         // 余剰分は非表示（fullRebuildOnUpdate=true なら基本来ないが安全のため）
@@ -210,6 +223,7 @@ public class PoseGridLayout : MonoBehaviour
 #else
             go = Instantiate(slotPrefab, contentRect);
 #endif
+            ConfigureButtonForIndex(go.GetComponent<ButtonPoseAction>(), i);
             go.name = $"Slot_{i:000}";
             go.SetActive(true);
         }
@@ -222,7 +236,15 @@ public class PoseGridLayout : MonoBehaviour
     {
         int current = contentRect.childCount;
         for (int i = 0; i < current; i++)
-            contentRect.GetChild(i).gameObject.SetActive(i < needed);
+        {
+            var child = contentRect.GetChild(i).gameObject;
+            bool active = i < needed;
+            child.SetActive(active);
+            if (active)
+            {
+                ConfigureButtonForIndex(child.GetComponent<ButtonPoseAction>(), i);
+            }
+        }
 
         for (int i = current; i < needed; i++)
         {
@@ -235,6 +257,7 @@ public class PoseGridLayout : MonoBehaviour
 #else
             go = Instantiate(slotPrefab, contentRect);
 #endif
+            ConfigureButtonForIndex(go.GetComponent<ButtonPoseAction>(), i);
             go.name = $"Slot_{i:000}";
             go.SetActive(true);
         }
@@ -251,6 +274,49 @@ public class PoseGridLayout : MonoBehaviour
             rt.anchorMin = new Vector2(0, 1);
             rt.anchorMax = new Vector2(1, 1);
             rt.anchoredPosition = new Vector2(0, rt.anchoredPosition.y);
+        }
+    }
+
+    public int TargetLayerIndex => targetLayerIndex;
+
+    public float CrossFadeTime => crossFadeTime;
+
+    public void SetTargetAnimator(Animator animator)
+    {
+        runtimeTargetAnimator = animator;
+        ApplyTargetAnimatorToChildren();
+    }
+
+    private Animator ResolveTargetAnimator()
+    {
+        return runtimeTargetAnimator ? runtimeTargetAnimator : editorTargetAnimator;
+    }
+
+    private void ConfigureButtonForIndex(ButtonPoseAction action, int index)
+    {
+        if (!action) return;
+        var targetAnimator = ResolveTargetAnimator();
+        var statePath = GetStatePathForIndex(index);
+        var clip = (index >= 0 && index < items.Count) ? items[index].clip : null;
+        action.Configure(targetAnimator, statePath, clip, crossFadeTime, targetLayerIndex);
+    }
+
+    private string GetStatePathForIndex(int index)
+    {
+        if (index < 0 || index >= items.Count) return string.Empty;
+        var it = items[index];
+        if (!string.IsNullOrEmpty(it.statePath)) return it.statePath;
+        return it.clip ? it.clip.name : string.Empty;
+    }
+
+    private void ApplyTargetAnimatorToChildren()
+    {
+        if (!contentRect) return;
+        for (int i = 0; i < contentRect.childCount; i++)
+        {
+            var action = contentRect.GetChild(i).GetComponent<ButtonPoseAction>();
+            if (!action) continue;
+            ConfigureButtonForIndex(action, i);
         }
     }
 

--- a/aiCam/Assets/Scripts/UI/Pose/PoseItem.cs
+++ b/aiCam/Assets/Scripts/UI/Pose/PoseItem.cs
@@ -7,4 +7,6 @@ public class PoseItem
     public Sprite thumbnail;
     [Tooltip("空なら clip.name を使う")]
     public string displayNameOverride;
+    [Tooltip("Animator のステートパス (例: SubState.State)")]
+    public string statePath;
 }

--- a/aiCam/Assets/Scripts/UI/Pose/PoseSlot.cs
+++ b/aiCam/Assets/Scripts/UI/Pose/PoseSlot.cs
@@ -14,15 +14,17 @@ public class PoseSlot : MonoBehaviour
     private AnimationClip clip;
     private int index;
     private string label;
+    private string statePath;
 
     /// <summary>
     /// thumbnail: null 可 / label: null または空なら clip.name を使う
     /// </summary>
-    public void Bind(AnimationClip clip, int index, Sprite thumbnail = null, string label = null)
+    public void Bind(AnimationClip clip, int index, Sprite thumbnail = null, string label = null, string statePath = null)
     {
         this.clip = clip;
         this.index = index;
         this.label = string.IsNullOrEmpty(label) ? (clip ? clip.name : "(None)") : label;
+        this.statePath = string.IsNullOrEmpty(statePath) ? (clip ? clip.name : string.Empty) : statePath;
 
         Image image = GetComponent<Image>();
         if(image) image.sprite = thumbnail;
@@ -42,8 +44,15 @@ public class PoseSlot : MonoBehaviour
 
     public void OnClick()
     {
-        Debug.Log($"Pose clicked: {index} - {clip?.name}");
-        // TODO: ここでアバターへ適用・選択制御など
+        var action = GetComponent<ButtonPoseAction>();
+        if (action)
+        {
+            action.Apply();
+        }
+        else
+        {
+            Debug.Log($"Pose clicked: {index} - {clip?.name} ({statePath})");
+        }
         SetSelected(true);
     }
 }


### PR DESCRIPTION
## Summary
- add editor tooling to populate PoseGridLayout items from Animator layer 2, mirroring the expression workflow
- store animator state paths on pose items and hook grid buttons up to a new ButtonPoseAction for triggering animations
- update the pose slot prefab and layout runtime to configure buttons with the resolved animator and state

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68eb58e5ace88332b4beaea82ba2f414